### PR TITLE
export LD_LIBRARY_PATH

### DIFF
--- a/esy.json
+++ b/esy.json
@@ -26,6 +26,10 @@
       "PKG_CONFIG_PATH": {
         "val": "#{self.lib / 'pkgconfig'}",
         "scope": "global"
+      },
+      "LD_LIBRARY_PATH": {
+        "val": "#{self.lib : $LD_LIBRARY_PATH}",
+        "scope": "global"
       }
     },
     "dependencies": {}


### PR DESCRIPTION
Hi ! Thanks for your packaging of sqlite, really useful for us :)

Exporting LD_LIBRARY_PATH is apparently necessary on Linux, otherwise at runtime the symbols will not be found.
I would expect DYLD_LIBRARY_PATH to be needed on MacOS, but it's doesn't seem necessary